### PR TITLE
fix: エディタレイアウト最終調整 + BlockNote padding修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,7 +185,7 @@ function App() {
       <div className="flex-1 flex flex-col min-w-0">
         {/* ヘッダーバー */}
         <div className="h-[45px] border-b border-notion-border flex-shrink-0">
-          <div className="h-full max-w-[708px] mx-auto px-24 flex items-center justify-between">
+          <div className="h-full max-w-[900px] mx-auto px-[96px] flex items-center justify-between">
             <div className="min-w-0 flex items-center gap-2 text-[13px] text-notion-secondary">
               {currentPage && (
                 <>

--- a/src/components/Editor/EditorArea.tsx
+++ b/src/components/Editor/EditorArea.tsx
@@ -73,10 +73,10 @@ export function EditorArea({
 
   return (
     <div className={`flex-1 overflow-y-auto ${fontClass}`}>
-      <div className="max-w-[708px] mx-auto px-24 pt-9 pb-32">
+      <div className="max-w-[900px] mx-auto px-[96px] pt-[72px] pb-32">
         {/* カバー画像 */}
         {page.cover_image && (
-          <div className="h-[220px] mb-7 -mx-24 overflow-hidden">
+          <div className="h-[220px] mb-7 -mx-[96px] overflow-hidden">
             <img
               src={page.cover_image}
               alt=""

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -134,11 +134,14 @@ textarea {
 
 .blocknote-wrapper .bn-container {
   font-family: var(--font-sans);
+  --bn-colors-editor-background: transparent;
 }
 
 .blocknote-wrapper .bn-editor {
   font-family: var(--font-sans);
   color: var(--color-notion-text);
+  padding-inline: 0;
+  background-color: transparent;
 }
 
 .blocknote-wrapper .bn-editor [class*="blockContent"] {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,7 +3,7 @@
 @theme {
   /* Notionカラーパレット - ライトモード（rgba系で柔らかく） */
   --color-notion-bg: #ffffff;
-  --color-notion-sidebar: #fbfbfa;
+  --color-notion-sidebar: #f7f7f5;
   --color-notion-text: rgba(55, 53, 47, 0.88);
   --color-notion-secondary: rgba(55, 53, 47, 0.65);
   --color-notion-tertiary: rgba(55, 53, 47, 0.38);


### PR DESCRIPTION
## 概要
- max-w-900px + px-96px でNotionのコンテンツ幅に準拠
- BlockNote内部の `padding-inline: 54px` を上書きして余白二重化を解消
- サイドバー背景色を #f7f7f5 に（白との差を明確化）
- `pnpm build` ✅