### PR TITLE
fix: Codex最終デザインレビュー - Notion実UI準拠の値に全面統一

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,7 +185,7 @@ function App() {
       <div className="flex-1 flex flex-col min-w-0">
         {/* ヘッダーバー */}
         <div className="h-[45px] border-b border-notion-border flex-shrink-0">
-          <div className="h-full max-w-[900px] mx-auto px-[96px] flex items-center justify-between">
+          <div className="h-full max-w-[912px] mx-auto px-[96px] flex items-center justify-between">
             <div className="min-w-0 flex items-center gap-2 text-[13px] text-notion-secondary">
               {currentPage && (
                 <>

--- a/src/components/Editor/EditorArea.tsx
+++ b/src/components/Editor/EditorArea.tsx
@@ -73,7 +73,7 @@ export function EditorArea({
 
   return (
     <div className={`flex-1 overflow-y-auto ${fontClass}`}>
-      <div className="max-w-[900px] mx-auto px-[96px] pt-[72px] pb-32">
+      <div className="max-w-[912px] mx-auto px-[96px] pt-[72px] pb-32">
         {/* カバー画像 */}
         {page.cover_image && (
           <div className="h-[220px] mb-7 -mx-[96px] overflow-hidden">
@@ -99,7 +99,7 @@ export function EditorArea({
           onChange={(e) => onUpdateTitle(e.target.value)}
           onKeyDown={handleTitleKeyDown}
           placeholder="無題"
-          className="w-full text-[40px] font-[600] leading-[1.05] tracking-[-0.03em] bg-transparent border-none outline-none text-notion-text placeholder:text-notion-tertiary mb-3"
+          className="w-full text-[40px] font-[700] leading-[48px] tracking-[-0.02em] bg-transparent border-none outline-none text-[#37352F] placeholder:text-[rgba(55,53,47,0.3)] mb-1 caret-[#37352F]"
         />
 
         {/* BlockNoteエディタ */}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -23,7 +23,7 @@ export function Sidebar({
   onDeletePage,
   onRefresh,
 }: SidebarProps) {
-  const [sidebarWidth] = useState(248);
+  const [sidebarWidth] = useState(224);
 
   const handleAddRootPage = useCallback(async () => {
     const id = await onAddPage(null);
@@ -36,7 +36,7 @@ export function Sidebar({
       style={{ width: sidebarWidth }}
     >
       {/* ワークスペース名 */}
-      <div className="h-11 px-3 flex items-center">
+      <div className="h-[45px] px-3 flex items-center">
         <span className="text-[14px] font-[500] text-notion-text truncate">
           Notion Clone
         </span>
@@ -44,8 +44,8 @@ export function Sidebar({
 
       {/* お気に入り */}
       {favorites.length > 0 && (
-        <div className="px-1 pt-3 pb-1">
-          <div className="px-3 py-1 text-[11px] font-[500] text-notion-secondary">
+        <div className="px-1 pt-1.5 pb-0.5">
+          <div className="px-3 py-1 text-[11px] leading-[18px] font-[500] text-notion-secondary">
             お気に入り
           </div>
           {favorites.map((page) => (
@@ -65,12 +65,12 @@ export function Sidebar({
       )}
 
       {/* ページ一覧 */}
-      <div className="flex-1 overflow-y-auto px-1 pt-3">
-        <div className="px-3 py-1 text-[11px] font-[500] text-notion-secondary flex items-center justify-between">
+      <div className="flex-1 overflow-y-auto px-1 pt-1.5">
+        <div className="px-3 py-1 text-[11px] leading-[18px] font-[500] text-notion-secondary flex items-center justify-between">
           <span>ページ</span>
           <button
             onClick={handleAddRootPage}
-            className="hover:bg-notion-hover rounded p-0.5 text-notion-secondary hover:text-notion-text transition-colors"
+            className="rounded-[6px] p-1 text-notion-secondary hover:bg-notion-hover hover:text-notion-text transition-colors"
             title="新規ページ"
           >
             <svg
@@ -100,30 +100,30 @@ export function Sidebar({
           />
         ))}
         {pages.length === 0 && (
-          <div className="px-3 py-4 text-xs text-notion-secondary text-center">
+          <div className="px-3 py-4 text-[12px] text-notion-secondary text-center">
             ページがありません
           </div>
         )}
       </div>
 
       {/* 下部: ゴミ箱 + 新規ページ */}
-      <div className="py-1.5 border-t border-notion-border">
+      <div className="py-1 border-t border-notion-border">
         <TrashSection onRestore={onRefresh} />
         <div className="px-1">
           <button
             onClick={handleAddRootPage}
-            className="w-full flex items-center gap-2 px-3 py-1.5 rounded text-[13px] text-notion-secondary hover:bg-notion-hover hover:text-notion-text transition-colors"
+            className="w-full h-[27px] flex items-center gap-2 px-3 rounded-[8px] text-[13px] leading-[20px] text-notion-secondary hover:bg-notion-hover hover:text-notion-text transition-colors"
           >
             <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
               fill="none"
               stroke="currentColor"
               strokeWidth="1.5"
             >
-              <line x1="8" y1="3" x2="8" y2="13" />
-              <line x1="3" y1="8" x2="13" y2="8" />
+              <line x1="7" y1="2" x2="7" y2="12" />
+              <line x1="2" y1="7" x2="12" y2="7" />
             </svg>
             新規ページ
           </button>

--- a/src/components/Sidebar/SidebarItem.tsx
+++ b/src/components/Sidebar/SidebarItem.tsx
@@ -95,38 +95,38 @@ export function SidebarItem({
   return (
     <div>
       <div
-        className={`group flex h-7 items-center gap-1 mx-1 rounded-[4px] cursor-pointer text-[13px] leading-[20px] transition-all ${
+        className={`group flex h-[27px] items-center gap-1 mx-1 rounded-[8px] cursor-pointer text-[13px] leading-[20px] transition-colors ${
           isActive
             ? "bg-notion-selected text-notion-text"
             : "text-notion-secondary hover:bg-notion-hover hover:text-notion-text"
         }`}
-        style={{ paddingLeft: `${depth * 12 + 6}px`, paddingRight: "6px" }}
+        style={{ paddingLeft: `${depth * 14 + 8}px`, paddingRight: "8px" }}
         onClick={() => onSelect(page.id)}
         onContextMenu={handleContextMenu}
       >
         {/* 展開/折りたたみ */}
         <button
           onClick={handleToggle}
-          className="flex-shrink-0 w-4 h-4 flex items-center justify-center rounded-[3px] opacity-0 group-hover:opacity-100 hover:bg-notion-hover transition-all"
+          className="flex-shrink-0 w-[18px] h-[18px] flex items-center justify-center rounded-[6px] text-notion-tertiary hover:bg-notion-hover hover:text-notion-text transition-colors"
         >
           <svg
-            width="8"
-            height="8"
-            viewBox="0 0 8 8"
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
             fill="currentColor"
             className={`transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
           >
-            <path d="M2 1L6 4L2 7Z" />
+            <path d="M3 1L8 5L3 9Z" />
           </svg>
         </button>
 
         {/* アイコン */}
-        <span className="flex-shrink-0 w-5 text-center text-[14px] leading-none opacity-90">
+        <span className="flex-shrink-0 w-[18px] text-center text-[14px] leading-none">
           {page.icon || "📄"}
         </span>
 
         {/* タイトル */}
-        <span className="truncate flex-1 font-[400]">
+        <span className="truncate flex-1 font-[500]">
           {page.title || "無題"}
         </span>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,15 +1,15 @@
 @import "tailwindcss";
 
 @theme {
-  /* Notionカラーパレット - ライトモード（rgba系で柔らかく） */
+  /* Notionカラーパレット - ライトモード */
   --color-notion-bg: #ffffff;
-  --color-notion-sidebar: #f7f7f5;
-  --color-notion-text: rgba(55, 53, 47, 0.88);
+  --color-notion-sidebar: #f7f6f3;
+  --color-notion-text: rgb(55, 53, 47);
   --color-notion-secondary: rgba(55, 53, 47, 0.65);
-  --color-notion-tertiary: rgba(55, 53, 47, 0.38);
+  --color-notion-tertiary: rgba(55, 53, 47, 0.3);
   --color-notion-border: rgba(55, 53, 47, 0.09);
-  --color-notion-hover: rgba(55, 53, 47, 0.04);
-  --color-notion-selected: rgba(55, 53, 47, 0.06);
+  --color-notion-hover: rgba(55, 53, 47, 0.08);
+  --color-notion-selected: rgba(55, 53, 47, 0.08);
 
   /* Notion 10色パレット - テキスト */
   --color-notion-gray: #787774;
@@ -47,7 +47,7 @@
   --color-notion-secondary: rgba(255, 255, 255, 0.44);
   --color-notion-tertiary: rgba(255, 255, 255, 0.28);
   --color-notion-border: rgba(255, 255, 255, 0.08);
-  --color-notion-hover: rgba(255, 255, 255, 0.04);
+  --color-notion-hover: rgba(255, 255, 255, 0.06);
   --color-notion-selected: rgba(255, 255, 255, 0.06);
 
   /* ダークモード 10色パレット - テキスト */
@@ -114,12 +114,12 @@ textarea {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-notion-border);
+  background: rgba(55, 53, 47, 0.12);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-notion-secondary);
+  background: rgba(55, 53, 47, 0.2);
 }
 
 /* 選択色 */
@@ -127,7 +127,10 @@ textarea {
   background: rgba(45, 170, 219, 0.3);
 }
 
-/* BlockNote カスタマイズ - Notion風 */
+/* ============================================ */
+/* BlockNote カスタマイズ - Notion準拠           */
+/* ============================================ */
+
 .blocknote-wrapper {
   min-height: 200px;
 }
@@ -139,43 +142,49 @@ textarea {
 
 .blocknote-wrapper .bn-editor {
   font-family: var(--font-sans);
-  color: var(--color-notion-text);
+  color: rgb(55, 53, 47);
   padding-inline: 0;
   background-color: transparent;
 }
 
-.blocknote-wrapper .bn-editor [class*="blockContent"] {
-  font-size: 16px;
-  line-height: 1.5;
-  padding: 3px 2px;
+/* ブロックコンテンツ */
+.blocknote-wrapper .bn-block-outer {
+  margin: 0;
 }
 
-/* 見出しサイズ - Notion準拠 */
+.blocknote-wrapper .bn-editor [class*="blockContent"] {
+  font-size: 16px;
+  line-height: 24px;
+  padding: 3px 2px;
+  color: rgb(55, 53, 47);
+}
+
+/* 見出し - Notion準拠の固定値 */
 .blocknote-wrapper .bn-editor h1 {
   font-size: 30px;
-  line-height: 1.15;
-  margin-top: 1.6em;
-  margin-bottom: 0.2em;
-  font-weight: 700;
+  line-height: 39px;
+  margin-top: 32px;
+  margin-bottom: 4px;
+  font-weight: 600;
 }
 
 .blocknote-wrapper .bn-editor h2 {
   font-size: 24px;
-  line-height: 1.2;
-  margin-top: 1.3em;
-  margin-bottom: 0.15em;
+  line-height: 31.2px;
+  margin-top: 32px;
+  margin-bottom: 4px;
   font-weight: 600;
 }
 
 .blocknote-wrapper .bn-editor h3 {
   font-size: 20px;
-  line-height: 1.25;
-  margin-top: 1em;
-  margin-bottom: 0.1em;
+  line-height: 26px;
+  margin-top: 32px;
+  margin-bottom: 4px;
   font-weight: 600;
 }
 
-/* BlockNoteのサイドメニュー（ドラッグハンドル） */
+/* ドラッグハンドル */
 .blocknote-wrapper .bn-side-menu {
   opacity: 0;
   transition: opacity 0.15s ease;
@@ -189,17 +198,55 @@ textarea {
   opacity: 1;
 }
 
-/* BlockNote ツールバー・メニュー */
-.blocknote-wrapper [class*="mantine-Menu"] {
-  border: 1px solid var(--color-notion-border);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04);
-}
-
 /* プレースホルダー */
 .blocknote-wrapper [class*="isEmpty"] [data-placeholder]::before {
-  color: var(--color-notion-secondary);
-  opacity: 0.38;
+  color: rgba(55, 53, 47, 0.3);
+  opacity: 1;
+}
+
+/* スラッシュメニュー - Notion準拠 */
+.blocknote-wrapper .bn-suggestion-menu,
+.blocknote-wrapper .bn-menu-dropdown,
+.blocknote-wrapper [class*="mantine-Menu"] {
+  width: 336px;
+  max-width: calc(100vw - 32px);
+  padding: 6px;
+  border: 1px solid rgba(55, 53, 47, 0.09);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow:
+    0 12px 32px rgba(15, 23, 42, 0.10),
+    0 2px 8px rgba(15, 23, 42, 0.06);
+}
+
+.blocknote-wrapper .bn-suggestion-menu-item {
+  min-height: 36px;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+.blocknote-wrapper .bn-suggestion-menu-item[aria-selected="true"] {
+  background: rgba(55, 53, 47, 0.08);
+}
+
+.blocknote-wrapper .bn-mt-suggestion-menu-item-title {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  color: rgb(55, 53, 47);
+}
+
+.blocknote-wrapper .bn-mt-suggestion-menu-item-subtitle {
+  font-size: 12px;
+  line-height: 16px;
+  color: rgba(55, 53, 47, 0.6);
+}
+
+.blocknote-wrapper .bn-suggestion-menu-label {
+  padding: 6px 10px 4px;
+  font-size: 11px;
+  line-height: 16px;
+  color: rgba(55, 53, 47, 0.6);
 }
 
 /* フォントスタイル切替 */


### PR DESCRIPTION
## 概要
Codexが実NotionのCSS値をウェブ検索で特定。全コンポーネントを実Notion準拠の値に統一。

### サイドバー
- 幅224px、行高27px、角丸8px、セクション間余白6px
- トグル矢印10px、ホバー色rgba(55,53,47,0.08)

### エディタ
- コンテンツ幅720px（912px - 96px×2）
- タイトル 40px/700weight/48px line-height/#37352F
- 本文 16px/24px line-height
- 見出し margin-top 32px固定

### スラッシュメニュー
- 幅336px、角丸8px、アイテム高36px、shadow調整

### ビルド確認
- `pnpm build` ✅